### PR TITLE
multiple code improvements: squid:S1066, squid:S1197, squid:S00117, squid:S1118, squid:CommentedOutCodeLine, squid:S00116

### DIFF
--- a/it.baeyens.arduino.monitor/src/it/baeyens/arduino/monitor/SerialConnection.java
+++ b/it.baeyens.arduino.monitor/src/it/baeyens/arduino/monitor/SerialConnection.java
@@ -3,13 +3,14 @@ package it.baeyens.arduino.monitor;
 import it.baeyens.arduino.monitor.views.SerialMonitor;
 
 public class SerialConnection {
-    public static void add(String comPort, int baudrate) {
-	SerialMonitor.getSerialMonitor().connectSerial(comPort, baudrate);
+    private SerialConnection() {}
 
+    public static void add(String comPort, int baudrate) {
+    SerialMonitor.getSerialMonitor().connectSerial(comPort, baudrate);
     }
 
     public static void remove(String comPort) {
-	SerialMonitor.getSerialMonitor().disConnectSerialPort(comPort);
+    SerialMonitor.getSerialMonitor().disConnectSerialPort(comPort);
     }
 
 }

--- a/it.baeyens.arduino.monitor/src/it/baeyens/arduino/monitor/internal/ScopeListener.java
+++ b/it.baeyens.arduino.monitor/src/it/baeyens/arduino/monitor/internal/ScopeListener.java
@@ -81,7 +81,6 @@ public class ScopeListener implements MessageConsumer {
 
     @Override
     public void dispose() {
-	// myScope.removeStackListener(0, stackAdapter);
 	this.myScope = null;
 	this.myReceivedScopeData = null;
     }

--- a/it.baeyens.arduino.monitor/src/it/baeyens/arduino/monitor/internal/SerialListener.java
+++ b/it.baeyens.arduino.monitor/src/it/baeyens/arduino/monitor/internal/SerialListener.java
@@ -16,9 +16,15 @@ import it.baeyens.arduino.monitor.views.SerialMonitor;
 
 public class SerialListener implements MessageConsumer {
     private static boolean myScopeFilterFlag = false;
-    SerialMonitor TheMonitor;
+    SerialMonitor theMonitor;
     int theColorIndex;
     private ByteBuffer myReceivedScopeData = ByteBuffer.allocate(2000);
+
+    public SerialListener(SerialMonitor monitor, int colorIndex) {
+	this.theMonitor = monitor;
+	this.theColorIndex = colorIndex;
+	this.myReceivedScopeData.order(ByteOrder.LITTLE_ENDIAN);
+    }
 
     public int removeBytesFromStart(int n) {
 	if (n == 0) {
@@ -33,12 +39,6 @@ public class SerialListener implements MessageConsumer {
 	}
 
 	return this.myReceivedScopeData.position(index).position();
-    }
-
-    public SerialListener(SerialMonitor Monitor, int ColorIndex) {
-	this.TheMonitor = Monitor;
-	this.theColorIndex = ColorIndex;
-	this.myReceivedScopeData.order(ByteOrder.LITTLE_ENDIAN);
     }
 
     @Override
@@ -64,18 +64,14 @@ public class SerialListener implements MessageConsumer {
 
     private void internalExtractAndRemoveScopeData() {
 
-	String MonitorMessage = Const.EMPTY_STRING;
+	String monitorMessage = Const.EMPTY_STRING;
 	boolean doneSearching = false;
 	int length = this.myReceivedScopeData.position();
-	// System.out.println(""); //$NON-NLS-1$
-	// System.out.print("start :>"); //$NON-NLS-1$
-	// System.out.print(new String(this.myReceivedScopeData.array()));
-	// System.out.println("<"); //$NON-NLS-1$
 	int searchPointer;
 	for (searchPointer = 0; (searchPointer < length - 1) && !doneSearching; searchPointer++) {
 	    if (this.myReceivedScopeData.getShort(searchPointer) != Const.SCOPE_START_DATA) {
 		char addChar = (char) this.myReceivedScopeData.get(searchPointer);
-		MonitorMessage += Character.toString(addChar);
+		monitorMessage += Character.toString(addChar);
 	    } else {
 		// have we received the full header of the scope data?
 		if (length < (searchPointer + 6)) {
@@ -122,18 +118,12 @@ public class SerialListener implements MessageConsumer {
 			addChar = ' ';
 		    }
 		    searchPointer++;
-		    MonitorMessage += Character.toString((char) addChar);
+		    monitorMessage += Character.toString((char) addChar);
 		}
 	    }
 	    removeBytesFromStart(searchPointer);
 	}
-
-	// System.out.print("done :"); //$NON-NLS-1$
-	// System.out.print(" :>"); //$NON-NLS-1$
-	// System.out.print(MonitorMessage);
-	// System.out.println("<"); //$NON-NLS-1$
-
-	event(MonitorMessage);
+	event(monitorMessage);
     }
 
     @Override
@@ -143,12 +133,12 @@ public class SerialListener implements MessageConsumer {
 
     @Override
     public void event(String event) {
-	final String TempString = new String(event);
+	final String tempString = new String(event);
 	Display.getDefault().asyncExec(new Runnable() {
 	    @Override
 	    public void run() {
 		try {
-		    SerialListener.this.TheMonitor.ReportSerialActivity(TempString, SerialListener.this.theColorIndex);
+		    SerialListener.this.theMonitor.ReportSerialActivity(tempString, SerialListener.this.theColorIndex);
 		} catch (Exception e) {// ignore as we get errors when closing
 				       // down
 		}

--- a/it.baeyens.cdt.refactor/src/it/baeyens/cdt/refactor/RenameFolderChangeHandler.java
+++ b/it.baeyens.cdt.refactor/src/it/baeyens/cdt/refactor/RenameFolderChangeHandler.java
@@ -58,7 +58,7 @@ public class RenameFolderChangeHandler extends Change {
 	for (int curProject = 0; curProject < projects.length; curProject++) {
 	    ICProjectDescription projectDescription = mngr.getProjectDescription(projects[curProject], true);
 	    if (projectDescription != null) { // if the description is null it probably is not a cdt project
-		ICConfigurationDescription configurationDescriptions[] = projectDescription.getConfigurations();
+		ICConfigurationDescription[] configurationDescriptions = projectDescription.getConfigurations();
 		boolean projectDescriptionChanged = false;
 		for (int curConfigDescription = 0; curConfigDescription < configurationDescriptions.length; curConfigDescription++) {
 
@@ -68,27 +68,25 @@ public class RenameFolderChangeHandler extends Change {
 		    // Add include path to all languages
 		    for (int idx = 0; idx < languageSettings.length; idx++) {
 			ICLanguageSetting lang = languageSettings[idx];
-			String LangID = lang.getLanguageId();
-			if (LangID != null) {
-			    if (LangID.startsWith("org.eclipse.cdt.")) { //$NON-NLS-1$
+			String langId = lang.getLanguageId();
+			if (langId != null && langId.startsWith("org.eclipse.cdt.")) { //$NON-NLS-1$
 				boolean languageChanged = false;
-				ICLanguageSettingEntry[] IncludeEntries = lang.getSettingEntries(ICSettingEntry.INCLUDE_PATH);
-				for (int curIncludeEntry = 0; curIncludeEntry < IncludeEntries.length; curIncludeEntry++) {
-				    if (IncludeEntries[curIncludeEntry].getName().startsWith(this.myOldName)) {
-					String newValue = IncludeEntries[curIncludeEntry].getName().replace(this.myOldName, this.myNewName);
+				ICLanguageSettingEntry[] includeEntries = lang.getSettingEntries(ICSettingEntry.INCLUDE_PATH);
+				for (int curIncludeEntry = 0; curIncludeEntry < includeEntries.length; curIncludeEntry++) {
+				    if (includeEntries[curIncludeEntry].getName().startsWith(this.myOldName)) {
+					String newValue = includeEntries[curIncludeEntry].getName().replace(this.myOldName, this.myNewName);
 					languageChanged = true;
 					projectDescriptionChanged = true;
-					IncludeEntries[curIncludeEntry] = new CIncludePathEntry(newValue, ICSettingEntry.VALUE_WORKSPACE_PATH);
+					includeEntries[curIncludeEntry] = new CIncludePathEntry(newValue, ICSettingEntry.VALUE_WORKSPACE_PATH);
 					Activator.getDefault().getLog()
 						.log(new Status(IStatus.INFO, "it.baeyens.cdt.refactor", //$NON-NLS-1$
 							"changed path from " + this.myOldName + " to " //$NON-NLS-1$ //$NON-NLS-2$
 								+ this.myNewName));
 				    }
 				}
-				if (languageChanged) {
-				    lang.setSettingEntries(ICSettingEntry.INCLUDE_PATH, IncludeEntries);
-				}
-			    }
+			if (languageChanged) {
+				lang.setSettingEntries(ICSettingEntry.INCLUDE_PATH, includeEntries);
+			}
 			}
 		    }
 		}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1066 - Collapsible "if" statements should be merged.
squid:S1197 - Array designators "[]" should be on the type, not the variable.
squid:S00117 - Local variable and method parameter names should comply with a naming convention.
squid:S1118 - Utility classes should not have public constructors.
squid:CommentedOutCodeLine - Sections of code should not be "commented out".
squid:S00116 - Field names should comply with a naming convention.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1066
https://dev.eclipse.org/sonar/rules/show/squid:S1197
https://dev.eclipse.org/sonar/rules/show/squid:S00117
https://dev.eclipse.org/sonar/rules/show/squid:S1118
https://dev.eclipse.org/sonar/rules/show/squid:CommentedOutCodeLine
https://dev.eclipse.org/sonar/rules/show/squid:S00116
Please let me know if you have any questions.
George Kankava
