### PR TITLE
multiple code improvements: squid:S1118, squid:S1197, squid:S1213, squid:S00117, squid:CommentedOutCodeLine, squid:S3008, squid:S00100, squid:S00116

### DIFF
--- a/it.baeyens.arduino.common/src/it/baeyens/arduino/common/Activator.java
+++ b/it.baeyens.arduino.common/src/it/baeyens/arduino/common/Activator.java
@@ -97,7 +97,7 @@ public class Activator extends AbstractUIPlugin {
 			} catch (BackingStoreException e) {
 			    // this should not happen
 			}
-			PleaseHelp.DoHelp(HELP_LOC);
+			PleaseHelp.doHelp(HELP_LOC);
 			return Status.OK_STATUS; // once per run will be
 						 // sufficient
 		}

--- a/it.baeyens.arduino.common/src/it/baeyens/arduino/common/Common.java
+++ b/it.baeyens.arduino.common/src/it/baeyens/arduino/common/Common.java
@@ -30,7 +30,7 @@ import it.baeyens.arduino.arduino.Serial;
 
 public class Common extends InstancePreferences {
 
-    static ISerialUser OtherSerialUser = null; // If someone else uses the
+    static ISerialUser otherSerialUser = null; // If someone else uses the
 					       // serial port he can register
 					       // here so we can
 					       // request him to disconnect
@@ -47,14 +47,14 @@ public class Common extends InstancePreferences {
      * @param serialUser
      */
     public static void registerSerialUser(ISerialUser serialUser) {
-	OtherSerialUser = serialUser;
+	otherSerialUser = serialUser;
     }
 
     /**
      * This method is to unregister a serial user.
      */
     public static void UnRegisterSerialUser() {
-	OtherSerialUser = null;
+	otherSerialUser = null;
     }
 
     /**
@@ -237,15 +237,15 @@ public class Common extends InstancePreferences {
     }
 
     public static boolean StopSerialMonitor(String mComPort) {
-	if (OtherSerialUser != null) {
-	    return OtherSerialUser.PauzePort(mComPort);
+	if (otherSerialUser != null) {
+	    return otherSerialUser.PauzePort(mComPort);
 	}
 	return false;
     }
 
     public static void StartSerialMonitor(String mComPort) {
-	if (OtherSerialUser != null) {
-	    OtherSerialUser.ResumePort(mComPort);
+	if (otherSerialUser != null) {
+	    otherSerialUser.ResumePort(mComPort);
 	}
 
     }
@@ -258,13 +258,13 @@ public class Common extends InstancePreferences {
     }
 
     public static String[] listBaudRates() {
-	String outgoing[] = { "115200", "57600", "38400", "31250", "28800", "19200", "14400", "9600", "4800", "2400", //$NON-NLS-1$//$NON-NLS-2$//$NON-NLS-3$//$NON-NLS-4$//$NON-NLS-5$//$NON-NLS-6$//$NON-NLS-7$ //$NON-NLS-8$ //$NON-NLS-9$ //$NON-NLS-10$
+	String[] outgoing = { "115200", "57600", "38400", "31250", "28800", "19200", "14400", "9600", "4800", "2400", //$NON-NLS-1$//$NON-NLS-2$//$NON-NLS-3$//$NON-NLS-4$//$NON-NLS-5$//$NON-NLS-6$//$NON-NLS-7$ //$NON-NLS-8$ //$NON-NLS-9$ //$NON-NLS-10$
 		"1200", "300" }; //$NON-NLS-1$ //$NON-NLS-2$
 	return outgoing;
     }
 
     public static String[] listLineEndings() {
-	String outgoing[] = { "none", "CR", "NL", "CR/NL" }; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+	String[] outgoing = { "none", "CR", "NL", "CR/NL" }; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 	return outgoing;
     }
 

--- a/it.baeyens.arduino.common/src/it/baeyens/arduino/common/ConfigurationPreferences.java
+++ b/it.baeyens.arduino.common/src/it/baeyens/arduino/common/ConfigurationPreferences.java
@@ -18,9 +18,8 @@ import org.osgi.service.prefs.BackingStoreException;
 public class ConfigurationPreferences {
 
     static private String stringSplitter = "\n";//$NON-NLS-1$
-    // private static final String defaulDownloadLocation = new
-    // Path(System.getProperty("user.home")).append("arduinoPlugin").toString();
-    // //$NON-NLS-1$ //$NON-NLS-2$
+
+    private ConfigurationPreferences() {}
 
     private static String getGlobalString(String key, String defaultValue) {
 	IEclipsePreferences myScope = ConfigurationScope.INSTANCE.getNode(Const.NODE_ARDUINO);
@@ -38,11 +37,11 @@ public class ConfigurationPreferences {
     }
 
     public static Path getInstallationPath() {
-	final String ArgStart = "-manager_path:"; //$NON-NLS-1$
-	String args[] = Platform.getApplicationArgs();
+	final String argStart = "-manager_path:"; //$NON-NLS-1$
+	String[] args = Platform.getApplicationArgs();
 	for (String arg : args) {
-	    if (arg.startsWith(ArgStart)) {
-		String pathName = arg.substring(ArgStart.length());
+	    if (arg.startsWith(argStart)) {
+		String pathName = arg.substring(argStart.length());
 		return new Path(pathName);
 	    }
 	}

--- a/it.baeyens.arduino.common/src/it/baeyens/arduino/common/Const.java
+++ b/it.baeyens.arduino.common/src/it/baeyens/arduino/common/Const.java
@@ -170,4 +170,6 @@ public class Const {
     public static final String POST_PROCESSING_PLATFORM_TXT = "post_processing_platform.txt";
     public static final String DEFINE_IN_ECLIPSE = "__IN_ECLIPSE__";
 
+    protected Const() {}
+
 }

--- a/it.baeyens.arduino.common/src/it/baeyens/arduino/common/Defaults.java
+++ b/it.baeyens.arduino.common/src/it/baeyens/arduino/common/Defaults.java
@@ -16,6 +16,8 @@ public class Defaults {
     public static final String[] INSTALLED_LIBRARIES = new String[] { "Ethernet", "Firmata", "GSM", "Keyboard",
 	    "LiquidCrystal", "Mouse", "SD", "Servo", "Stepper", "TFT", "WiFi" };
 
+    private Defaults () {}
+
     /**
      * Arduino has the default libraries in the user home directory in subfolder
      * Arduino/libraries. As the home directory is platform dependent getting

--- a/it.baeyens.arduino.common/src/it/baeyens/arduino/common/InstancePreferences.java
+++ b/it.baeyens.arduino.common/src/it/baeyens/arduino/common/InstancePreferences.java
@@ -25,6 +25,8 @@ import org.osgi.service.prefs.BackingStoreException;
  */
 public class InstancePreferences extends Const {
 
+	private static boolean mIsConfigured = false;
+
 	public static boolean getOpenSerialWithMonitor() {
 		return getGlobalBoolean(KEY_OPEN_SERIAL_WITH_MONITOR, Defaults.OPEN_SERIAL_WITH_MONITOR);
 	}
@@ -75,8 +77,8 @@ public class InstancePreferences extends Const {
 			public void run() {
 				Shell theShell = PlatformUI.getWorkbench().getDisplay().getActiveShell();
 				MessageBox dialog = new MessageBox(theShell, SWT.ICON_QUESTION | SWT.YES | SWT.NO);
-				dialog.setText(Messages.Build_before_upload);
-				dialog.setMessage(Messages.do_you_want_to_build_before_upload);
+				dialog.setText(Messages.buildBeforeUpload);
+				dialog.setMessage(Messages.doYouWantToBuildBeforeUpload);
 				switch (dialog.open()) {
 				case SWT.NO:
 					this.ret = false;
@@ -119,26 +121,26 @@ public class InstancePreferences extends Const {
 	/**
 	 * saves the last used arduino upload port
 	 * 
-	 * @param UploadPort
+	 * @param uploadPort
 	 *            The port to use to upload to save
 	 * 
 	 * @author Jan Baeyens
 	 */
-	public static void setLastUsedUploadPort(String UploadPort) {
-		setGlobalValue(KEY_LAST_USED_COM_PORT, UploadPort);
+	public static void setLastUsedUploadPort(String uploadPort) {
+		setGlobalValue(KEY_LAST_USED_COM_PORT, uploadPort);
 
 	}
 
 	/**
 	 * saves the last used arduino board name
 	 * 
-	 * @param ArduinoBoardName
+	 * @param arduinoBoardName
 	 *            The arduino board name to save
 	 * 
 	 * @author Jan Baeyens
 	 */
-	public static void setLastUsedArduinoBoard(String ArduinoBoardName) {
-		setGlobalValue(KEY_LAST_USED_BOARD, ArduinoBoardName);
+	public static void setLastUsedArduinoBoard(String arduinoBoardName) {
+		setGlobalValue(KEY_LAST_USED_BOARD, arduinoBoardName);
 	}
 
 	public static String getGlobalString(String key, String defaultValue) {
@@ -161,10 +163,10 @@ public class InstancePreferences extends Const {
 		return myScope.getLong(key, 0);
 	}
 
-	public static void setGlobalValue(String key, String Value) {
+	public static void setGlobalValue(String key, String value) {
 
 		IEclipsePreferences myScope = InstanceScope.INSTANCE.getNode(NODE_ARDUINO);
-		myScope.put(key, Value);
+		myScope.put(key, value);
 		try {
 			myScope.flush();
 		} catch (BackingStoreException e) {
@@ -174,9 +176,9 @@ public class InstancePreferences extends Const {
 		}
 	}
 
-	protected static void setGlobalValue(String key, int Value) {
+	protected static void setGlobalValue(String key, int value) {
 		IEclipsePreferences myScope = InstanceScope.INSTANCE.getNode(NODE_ARDUINO);
-		myScope.putInt(key, Value);
+		myScope.putInt(key, value);
 		try {
 			myScope.flush();
 		} catch (BackingStoreException e) {
@@ -185,9 +187,9 @@ public class InstancePreferences extends Const {
 		}
 	}
 
-	protected static void setGlobalValue(String key, boolean Value) {
+	protected static void setGlobalValue(String key, boolean value) {
 		IEclipsePreferences myScope = InstanceScope.INSTANCE.getNode(NODE_ARDUINO);
-		myScope.putBoolean(key, Value);
+		myScope.putBoolean(key, value);
 		try {
 			myScope.flush();
 		} catch (BackingStoreException e) {
@@ -197,9 +199,9 @@ public class InstancePreferences extends Const {
 		}
 	}
 
-	protected static void setGlobalValue(String key, long Value) {
+	protected static void setGlobalValue(String key, long value) {
 		IEclipsePreferences myScope = InstanceScope.INSTANCE.getNode(NODE_ARDUINO);
-		myScope.putLong(key, Value);
+		myScope.putLong(key, value);
 		try {
 			myScope.flush();
 		} catch (BackingStoreException e) {
@@ -261,17 +263,15 @@ public class InstancePreferences extends Const {
 	public static Map<String, String> getLastUsedMenuOption() {
 		Map<String, String> options = new HashMap<>();
 		String storedValue = getGlobalString(KEY_LAST_USED_BOARD_MENU_OPTIONS, ""); //$NON-NLS-1$
-		String lines[] = storedValue.split("\n"); //$NON-NLS-1$
+		String[] lines = storedValue.split("\n"); //$NON-NLS-1$
 		for (String curLine : lines) {
-			String values[] = curLine.split("=", 2); //$NON-NLS-1$
+			String[] values = curLine.split("=", 2); //$NON-NLS-1$
 			if (values.length == 2) {
 				options.put(values[0], values[1]);
 			}
 		}
 		return options;
 	}
-
-	private static boolean mIsConfigured = false;
 
 	public static void setConfigured() {
 		mIsConfigured = true;
@@ -289,7 +289,7 @@ public class InstancePreferences extends Const {
 		if (showError) {
 			// If not then we bail out with an error.
 			// And no pages are presented (with no option to FINISH).
-			Common.log(new Status(IStatus.ERROR, Const.CORE_PLUGIN_ID, Messages.Please_wait_for_installer_job, null));
+			Common.log(new Status(IStatus.ERROR, Const.CORE_PLUGIN_ID, Messages.pleaseWaitForInstallerJob, null));
 		}
 		return false;
 	}

--- a/it.baeyens.arduino.common/src/it/baeyens/arduino/common/Messages.java
+++ b/it.baeyens.arduino.common/src/it/baeyens/arduino/common/Messages.java
@@ -4,9 +4,9 @@ import org.eclipse.osgi.util.NLS;
 
 public class Messages extends NLS {
     private static final String BUNDLE_NAME = "it.baeyens.arduino.common.messages"; //$NON-NLS-1$
-    public static String Build_before_upload;
-    public static String do_you_want_to_build_before_upload;
-    public static String Please_wait_for_installer_job;
+    public static String buildBeforeUpload;
+    public static String doYouWantToBuildBeforeUpload;
+    public static String pleaseWaitForInstallerJob;
 
     static {
 	// initialize resource bundle

--- a/it.baeyens.arduino.common/src/it/baeyens/arduino/common/PleaseHelp.java
+++ b/it.baeyens.arduino.common/src/it/baeyens/arduino/common/PleaseHelp.java
@@ -18,13 +18,18 @@ import org.osgi.framework.FrameworkUtil;
 
 public class PleaseHelp extends Dialog {
 
-    @Override
-    protected void handleShellCloseEvent() {// JABA is not going to add code
-    }
-
     public Browser browser = null;
     public PleaseHelp ph;
     private static String myhelpLocation;
+
+    public PleaseHelp(Shell parent) {
+	super(parent);
+	this.ph = this;
+    }
+
+    @Override
+    protected void handleShellCloseEvent() {// JABA is not going to add code
+    }
 
     @Override
     protected Control createContents(Composite parent) {
@@ -79,7 +84,7 @@ public class PleaseHelp extends Dialog {
      * Static helper function to popup the help jantje page
      * 
      */
-    static void DoHelp(String helpLocation) {
+    static void doHelp(String helpLocation) {
 	myhelpLocation = helpLocation;
 	PlatformUI.getWorkbench().getDisplay().asyncExec(new Runnable() {
 	    @Override
@@ -94,11 +99,4 @@ public class PleaseHelp extends Dialog {
     protected Point getInitialSize() {
 	return this.getShell().computeSize(SWT.MAX, SWT.MAX, true);
     }
-
-    public PleaseHelp(Shell parent) {
-	super(parent);
-	this.ph = this;
-
-    }
-
 }

--- a/it.baeyens.arduino.common/test/it/baeyens/arduino/common/test/ArduinoIDEVersionNameParsing.java
+++ b/it.baeyens.arduino.common/test/it/baeyens/arduino/common/test/ArduinoIDEVersionNameParsing.java
@@ -8,39 +8,38 @@ import org.junit.Test;
 
 public class ArduinoIDEVersionNameParsing {
 
-    private Map<String, String> VersionList;
+    private Map<String, String> versionList;
 
     @Test
     public void testAllArduinoVersions() {
-	this.VersionList = new LinkedHashMap<>();
+	this.versionList = new LinkedHashMap<>();
 	// The tests below have been deactivated as they fail
 	// and the plugin does not support these versions
 	// VersionList.put("1.0.1", "101");
 	// VersionList.put("1.0.2", "102");
 	// VersionList.put("1.0.3", "103");
 	// VersionList.put("1.0.4", "104");
-	this.VersionList.put("1.5.1", "151"); //$NON-NLS-1$ //$NON-NLS-2$
-	this.VersionList.put("1.5.2", "152"); //$NON-NLS-1$ //$NON-NLS-2$
-	this.VersionList.put("1.5.3", "153"); //$NON-NLS-1$ //$NON-NLS-2$
-	this.VersionList.put("1.5.4", "154"); //$NON-NLS-1$ //$NON-NLS-2$
-	this.VersionList.put("1.5.5", "155"); //$NON-NLS-1$ //$NON-NLS-2$
-	this.VersionList.put("1.5.6", "156"); //$NON-NLS-1$ //$NON-NLS-2$
-	this.VersionList.put("1.5.6-r2", "156"); //$NON-NLS-1$ //$NON-NLS-2$
-	this.VersionList.put("1.5.7", "157"); //$NON-NLS-1$ //$NON-NLS-2$
-	this.VersionList.put("1.5.8", "158"); //$NON-NLS-1$ //$NON-NLS-2$
-	this.VersionList.put("1.6.0", "10600"); //$NON-NLS-1$ //$NON-NLS-2$
-	this.VersionList.put("1.6.1", "10601"); //$NON-NLS-1$ //$NON-NLS-2$
-	this.VersionList.put("1.6.2", "10602"); //$NON-NLS-1$ //$NON-NLS-2$
-	this.VersionList.put("1.6.3", "10603"); //$NON-NLS-1$ //$NON-NLS-2$
-	this.VersionList.put("1.6.4", "10604"); //$NON-NLS-1$ //$NON-NLS-2$
-	this.VersionList.put("1.6.5", "10605"); //$NON-NLS-1$ //$NON-NLS-2$
-	this.VersionList.put("1.6.5-r2", "10605"); //$NON-NLS-1$ //$NON-NLS-2$
-	this.VersionList.put("1.6.5-r3", "10605"); //$NON-NLS-1$ //$NON-NLS-2$
-	this.VersionList.put("1.6.5-r4", "10605"); //$NON-NLS-1$ //$NON-NLS-2$
-	this.VersionList.put("1.6.5-r5", "10605"); //$NON-NLS-1$ //$NON-NLS-2$
+	this.versionList.put("1.5.1", "151"); //$NON-NLS-1$ //$NON-NLS-2$
+	this.versionList.put("1.5.2", "152"); //$NON-NLS-1$ //$NON-NLS-2$
+	this.versionList.put("1.5.3", "153"); //$NON-NLS-1$ //$NON-NLS-2$
+	this.versionList.put("1.5.4", "154"); //$NON-NLS-1$ //$NON-NLS-2$
+	this.versionList.put("1.5.5", "155"); //$NON-NLS-1$ //$NON-NLS-2$
+	this.versionList.put("1.5.6", "156"); //$NON-NLS-1$ //$NON-NLS-2$
+	this.versionList.put("1.5.6-r2", "156"); //$NON-NLS-1$ //$NON-NLS-2$
+	this.versionList.put("1.5.7", "157"); //$NON-NLS-1$ //$NON-NLS-2$
+	this.versionList.put("1.5.8", "158"); //$NON-NLS-1$ //$NON-NLS-2$
+	this.versionList.put("1.6.0", "10600"); //$NON-NLS-1$ //$NON-NLS-2$
+	this.versionList.put("1.6.1", "10601"); //$NON-NLS-1$ //$NON-NLS-2$
+	this.versionList.put("1.6.2", "10602"); //$NON-NLS-1$ //$NON-NLS-2$
+	this.versionList.put("1.6.3", "10603"); //$NON-NLS-1$ //$NON-NLS-2$
+	this.versionList.put("1.6.4", "10604"); //$NON-NLS-1$ //$NON-NLS-2$
+	this.versionList.put("1.6.5", "10605"); //$NON-NLS-1$ //$NON-NLS-2$
+	this.versionList.put("1.6.5-r2", "10605"); //$NON-NLS-1$ //$NON-NLS-2$
+	this.versionList.put("1.6.5-r3", "10605"); //$NON-NLS-1$ //$NON-NLS-2$
+	this.versionList.put("1.6.5-r4", "10605"); //$NON-NLS-1$ //$NON-NLS-2$
+	this.versionList.put("1.6.5-r5", "10605"); //$NON-NLS-1$ //$NON-NLS-2$
 	for (@SuppressWarnings("unused")
-	Entry<String, String> currentVersion : this.VersionList.entrySet()) {
-	    // assertEquals(currentVersion.getValue(), ArduinoInstancePreferences.GetArduinoDefineValueInternal(currentVersion.getKey()));
+	Entry<String, String> currentVersion : this.versionList.entrySet()) {
 	}
     }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1118 - Utility classes should not have public constructors.
squid:S1197 - Array designators "[]" should be on the type, not the variable.
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
squid:S00117 - Local variable and method parameter names should comply with a naming convention.
squid:CommentedOutCodeLine - Sections of code should not be "commented out".
squid:S3008 - Static non-final field names should comply with a naming convention.
squid:S00100 - Method names should comply with a naming convention.
squid:S00116 - Field names should comply with a naming convention.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
https://dev.eclipse.org/sonar/rules/show/squid:S1197
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:S00117
https://dev.eclipse.org/sonar/rules/show/squid:CommentedOutCodeLine
https://dev.eclipse.org/sonar/rules/show/squid:S3008
https://dev.eclipse.org/sonar/rules/show/squid:S00100
https://dev.eclipse.org/sonar/rules/show/squid:S00116
Please let me know if you have any questions.
George Kankava
