### PR TITLE
multiple code improvements: squid:CommentedOutCodeLine, squid:S00108, squid:S3008, squid:S1213, squid:S00117, squid:S00116, squid:S1066, squid:S00115, squid:S1197, squid:S2184, squid:UselessParenthesesCheck

### DIFF
--- a/it.baeyens.arduino.common/test/it/baeyens/arduino/common/test/ArduinoIDEVersionNameParsing.java
+++ b/it.baeyens.arduino.common/test/it/baeyens/arduino/common/test/ArduinoIDEVersionNameParsing.java
@@ -13,12 +13,6 @@ public class ArduinoIDEVersionNameParsing {
     @Test
     public void testAllArduinoVersions() {
 	this.versionList = new LinkedHashMap<>();
-	// The tests below have been deactivated as they fail
-	// and the plugin does not support these versions
-	// VersionList.put("1.0.1", "101");
-	// VersionList.put("1.0.2", "102");
-	// VersionList.put("1.0.3", "103");
-	// VersionList.put("1.0.4", "104");
 	this.versionList.put("1.5.1", "151"); //$NON-NLS-1$ //$NON-NLS-2$
 	this.versionList.put("1.5.2", "152"); //$NON-NLS-1$ //$NON-NLS-2$
 	this.versionList.put("1.5.3", "153"); //$NON-NLS-1$ //$NON-NLS-2$
@@ -38,8 +32,5 @@ public class ArduinoIDEVersionNameParsing {
 	this.versionList.put("1.6.5-r3", "10605"); //$NON-NLS-1$ //$NON-NLS-2$
 	this.versionList.put("1.6.5-r4", "10605"); //$NON-NLS-1$ //$NON-NLS-2$
 	this.versionList.put("1.6.5-r5", "10605"); //$NON-NLS-1$ //$NON-NLS-2$
-	for (@SuppressWarnings("unused")
-	Entry<String, String> currentVersion : this.versionList.entrySet()) {
-	}
     }
 }

--- a/it.baeyens.arduino.monitor/src/it/baeyens/arduino/monitor/internal/ScopeListener.java
+++ b/it.baeyens.arduino.monitor/src/it/baeyens/arduino/monitor/internal/ScopeListener.java
@@ -69,7 +69,7 @@ public class ScopeListener implements MessageConsumer {
 	    return;
 	if (this.myEndPosition + newData.length >= this.myReceivedScopeData.capacity()) {
 	    this.myEndPosition = 0;
-	    Common.log(new Status(IStatus.WARNING, Const.CORE_PLUGIN_ID, Messages.SerialListener_scope_skipping_data));
+	    Common.log(new Status(IStatus.WARNING, Const.CORE_PLUGIN_ID, Messages.serialListenerScopeSkippingData));
 	} else {
 	    this.myReceivedScopeData.position(this.myEndPosition);
 	    this.myReceivedScopeData.put(newData, 0, newData.length);
@@ -125,8 +125,8 @@ public class ScopeListener implements MessageConsumer {
 		int bytestoRead = this.myReceivedScopeData.getShort(scannnedDataPointer);
 		if ((bytestoRead < 0) || (bytestoRead > 10 * 2)) {
 		    Common.log(
-			    new Status(IStatus.WARNING, Const.CORE_PLUGIN_ID, Messages.SerialListener_error_input_part_1
-				    + bytestoRead / 2 + ' ' + Messages.SerialListener_error_input_part_2));
+			    new Status(IStatus.WARNING, Const.CORE_PLUGIN_ID, Messages.serialListenerErrorInputPart1
+				    + bytestoRead / 2 + ' ' + Messages.serialListenerErrorInputPart2));
 		} else {
 		    if (bytestoRead + 2 + scannnedDataPointer < this.myEndPosition) {
 			// all data is available
@@ -149,7 +149,7 @@ public class ScopeListener implements MessageConsumer {
 		this.myReceivedScopeData.put(curByte, this.myReceivedScopeData.get(curByte + lastFoundData));
 	    } catch (IndexOutOfBoundsException e) {
 		Common.log(
-			new Status(IStatus.WARNING, Const.CORE_PLUGIN_ID, Messages.ScopeListener_buffer_overflow, e));
+			new Status(IStatus.WARNING, Const.CORE_PLUGIN_ID, Messages.scopeListenerBufferOverflow, e));
 	    }
 
 	}

--- a/it.baeyens.arduino.monitor/src/it/baeyens/arduino/monitor/internal/SerialListener.java
+++ b/it.baeyens.arduino.monitor/src/it/baeyens/arduino/monitor/internal/SerialListener.java
@@ -50,7 +50,7 @@ public class SerialListener implements MessageConsumer {
 	    } catch (BufferOverflowException e) {
 		this.myReceivedScopeData.clear();
 		Common.log(
-			new Status(IStatus.WARNING, Const.CORE_PLUGIN_ID, Messages.SerialListener_scope_skipping_data));
+			new Status(IStatus.WARNING, Const.CORE_PLUGIN_ID, Messages.serialListenerScopeSkippingData));
 	    }
 	    internalExtractAndRemoveScopeData();
 	} else {
@@ -84,8 +84,8 @@ public class SerialListener implements MessageConsumer {
 		    int bytestoRead = this.myReceivedScopeData.getShort(2);
 		    if ((bytestoRead < 0) || (bytestoRead > (10 * 2))) {
 			Common.log(new Status(IStatus.WARNING, Const.CORE_PLUGIN_ID,
-				Messages.SerialListener_error_input_part_1 + bytestoRead / 2
-					+ Messages.SerialListener_error_input_part_2));
+				Messages.serialListenerErrorInputPart1 + bytestoRead / 2
+					+ Messages.serialListenerErrorInputPart2));
 			searchPointer += 4;// skip the scope start and length so
 					   // data is shown
 			// System.out.println("case 2"); //$NON-NLS-1$

--- a/it.baeyens.arduino.monitor/src/it/baeyens/arduino/monitor/views/ComPortChanged.java
+++ b/it.baeyens.arduino.monitor/src/it/baeyens/arduino/monitor/views/ComPortChanged.java
@@ -4,15 +4,15 @@ import org.eclipse.jface.viewers.ISelectionChangedListener;
 import org.eclipse.jface.viewers.SelectionChangedEvent;
 
 public class ComPortChanged implements ISelectionChangedListener {
-    private SerialMonitor TheSerialMonitor;
+    private SerialMonitor theSerialMonitor;
 
-    public ComPortChanged(SerialMonitor TheSerialMonitor) {
-	this.TheSerialMonitor = TheSerialMonitor;
+    public ComPortChanged(SerialMonitor theSerialMonitor) {
+	this.theSerialMonitor = theSerialMonitor;
     }
 
     @Override
     public void selectionChanged(SelectionChangedEvent event) {
-	this.TheSerialMonitor.ComboSerialChanged();
+	this.theSerialMonitor.ComboSerialChanged();
     }
 
 }

--- a/it.baeyens.arduino.monitor/src/it/baeyens/arduino/monitor/views/Messages.java
+++ b/it.baeyens.arduino.monitor/src/it/baeyens/arduino/monitor/views/Messages.java
@@ -4,30 +4,30 @@ import org.eclipse.osgi.util.NLS;
 
 public class Messages extends NLS {
     private static final String BUNDLE_NAME = "it.baeyens.arduino.monitor.views.messages"; //$NON-NLS-1$
-    public static String OpenSerialDialogBox_Select_the_baut_rate;
-    public static String OpenSerialDialogBox_Serial_port_to_connect_to;
-    public static String OpenSerialDialogBox_Dtr;
-    public static String ScopeListener_buffer_overflow;
-    public static String ScopeView_channel;
-    public static String ScopeView_connected_to;
-    public static String ScopeView_disconnected_from;
-    public static String ScopeView_serial_message_missed;
-    public static String SerialListener_error_input_part_1;
-    public static String SerialListener_error_input_part_2;
-    public static String SerialListener_scope_skipping_data;
-    public static String SerialMonitor_Add_connection_to_seral_monitor;
-    public static String SerialMonitor_at;
-    public static String SerialMonitor_scroll_lock;
-    public static String SerialMonitor_clear;
-    public static String SerialMonitor_connected_to;
-    public static String SerialMonitor_connectedt_to;
-    public static String SerialMonitor_disconnected_from;
-    public static String SerialMonitor_filter_scope;
-    public static String SerialMonitor_no_input;
-    public static String SerialMonitor_no_more_serial_ports_supported;
-    public static String SerialMonitor_remove_serial_port_from_monitor;
-    public static String SerialMonitor_reset;
-    public static String SerialMonitor_send;
+    public static String openSerialDialogBoxSelectTheBautRate;
+    public static String openSerialDialogBoxSerialPortToConnectTo;
+    public static String openSerialDialogBoxDtr;
+    public static String scopeListenerBufferOverflow;
+    public static String scopeViewChannel;
+    public static String scopeViewConnectedTo;
+    public static String scopeViewDisconnectedFrom;
+    public static String scopeViewSerialMessageMissed;
+    public static String serialListenerErrorInputPart1;
+    public static String serialListenerErrorInputPart2;
+    public static String serialListenerScopeSkippingData;
+    public static String serialMonitorAddConnectionToSeralMonitor;
+    public static String serialMonitorAt;
+    public static String serialMonitorScrollLock;
+    public static String serialMonitorClear;
+    public static String serialMonitorConnectedTo;
+    public static String serialMonitorConnectedtTo;
+    public static String serialMonitorDisconnectedFrom;
+    public static String serialMonitorFilterScope;
+    public static String serialMonitorNoInput;
+    public static String serialMonitorNoMoreSerialPortsSupported;
+    public static String serialMonitorRemoveSerialPortFromMonitor;
+    public static String serialMonitorReset;
+    public static String serialMonitorSend;
 
     static {
 	// initialize resource bundle

--- a/it.baeyens.arduino.monitor/src/it/baeyens/arduino/monitor/views/OpenSerialDialogBox.java
+++ b/it.baeyens.arduino.monitor/src/it/baeyens/arduino/monitor/views/OpenSerialDialogBox.java
@@ -18,36 +18,33 @@ import it.baeyens.arduino.common.InstancePreferences;
 import it.baeyens.arduino.common.Common;
 
 public class OpenSerialDialogBox extends Dialog {
+    private ComboViewer serialPorts;
+    private ComboViewer baudRates;
+    private Button dtrCheckbox;
+    private String selectedPort;
+    private int selectedRate;
+    private boolean selectedDtr;
+
+    protected OpenSerialDialogBox(Shell parentShell) {
+	super(parentShell);
+    }
+
     @Override
     protected void okPressed() {
 	// I need to save these values in local variables as the GUI stuff is
 	// deleted after he close
-	this.SelectedRate = Integer.parseInt(this.BaudRates.getCombo().getText());
-	this.SelectedPort = this.SerialPorts.getCombo().getText();
-	this.SelectedDtr = this.DtrCheckbox.getSelection();
-	InstancePreferences.setGlobalValue(Const.KEY_SERIAL_RATE, this.BaudRates.getCombo().getText());
-	InstancePreferences.setGlobalValue(Const.KEY_SERIAL_PORT, this.SelectedPort);
+	this.selectedRate = Integer.parseInt(this.baudRates.getCombo().getText());
+	this.selectedPort = this.serialPorts.getCombo().getText();
+	this.selectedDtr = this.dtrCheckbox.getSelection();
+	InstancePreferences.setGlobalValue(Const.KEY_SERIAL_RATE, this.baudRates.getCombo().getText());
+	InstancePreferences.setGlobalValue(Const.KEY_SERIAL_PORT, this.selectedPort);
 	super.okPressed();
-    }
-
-    private ComboViewer SerialPorts;
-    private ComboViewer BaudRates;
-    private Button DtrCheckbox;
-    // private ComboViewer LineEndings;
-    private String SelectedPort;
-    private int SelectedRate;
-    private boolean SelectedDtr;
-
-    protected OpenSerialDialogBox(Shell parentShell) {
-	super(parentShell);
-
     }
 
     @Override
     protected Control createDialogArea(Composite parent) {
 	GridLayout layout = new GridLayout();
 	layout.numColumns = 2;
-	// layout.horizontalAlignment = GridData.FILL;
 	parent.setLayout(layout);
 
 	// The text fields will grow with the size of the dialog
@@ -57,50 +54,50 @@ public class OpenSerialDialogBox extends Dialog {
 
 	// Create the serial port combo box to allow to select a serial port
 	Label label1 = new Label(parent, SWT.NONE);
-	label1.setText(Messages.OpenSerialDialogBox_Serial_port_to_connect_to);
+	label1.setText(Messages.openSerialDialogBoxSerialPortToConnectTo);
 
 	// If there are no comports allow to provide one
 	String[] comPorts = Common.listComPorts();
 	if (comPorts.length == 0) {
-	    this.SerialPorts = new ComboViewer(parent, SWT.DROP_DOWN);
+	    this.serialPorts = new ComboViewer(parent, SWT.DROP_DOWN);
 	} else {
-	    this.SerialPorts = new ComboViewer(parent, SWT.READ_ONLY | SWT.DROP_DOWN);
+	    this.serialPorts = new ComboViewer(parent, SWT.READ_ONLY | SWT.DROP_DOWN);
 	}
-	this.SerialPorts.getControl().setLayoutData(new GridData(SWT.LEFT, SWT.NONE, false, false));
-	this.SerialPorts.setContentProvider(new ArrayContentProvider());
-	this.SerialPorts.setLabelProvider(new LabelProvider());
-	this.SerialPorts.setInput(comPorts);
+	this.serialPorts.getControl().setLayoutData(new GridData(SWT.LEFT, SWT.NONE, false, false));
+	this.serialPorts.setContentProvider(new ArrayContentProvider());
+	this.serialPorts.setLabelProvider(new LabelProvider());
+	this.serialPorts.setInput(comPorts);
 
 	// Create baud rate selection combo box to select the baud rate
 	Label label2 = new Label(parent, SWT.NONE);
-	label2.setText(Messages.OpenSerialDialogBox_Select_the_baut_rate);
-	this.BaudRates = new ComboViewer(parent, SWT.READ_ONLY | SWT.DROP_DOWN);
-	this.BaudRates.getControl().setLayoutData(new GridData(SWT.LEFT, SWT.NONE, false, false));
-	this.BaudRates.setContentProvider(new ArrayContentProvider());
-	this.BaudRates.setLabelProvider(new LabelProvider());
-	this.BaudRates.setInput(Common.listBaudRates());
+	label2.setText(Messages.openSerialDialogBoxSelectTheBautRate);
+	this.baudRates = new ComboViewer(parent, SWT.READ_ONLY | SWT.DROP_DOWN);
+	this.baudRates.getControl().setLayoutData(new GridData(SWT.LEFT, SWT.NONE, false, false));
+	this.baudRates.setContentProvider(new ArrayContentProvider());
+	this.baudRates.setLabelProvider(new LabelProvider());
+	this.baudRates.setInput(Common.listBaudRates());
 
-	this.BaudRates.getCombo().setText(InstancePreferences.getGlobalString(Const.KEY_SERIAL_RATE, Const.EMPTY_STRING));
-	this.SerialPorts.getCombo().setText(InstancePreferences.getGlobalString(Const.KEY_SERIAL_PORT, Const.EMPTY_STRING));
+	this.baudRates.getCombo().setText(InstancePreferences.getGlobalString(Const.KEY_SERIAL_RATE, Const.EMPTY_STRING));
+	this.serialPorts.getCombo().setText(InstancePreferences.getGlobalString(Const.KEY_SERIAL_PORT, Const.EMPTY_STRING));
 	
-	this.DtrCheckbox = new Button(parent, SWT.CHECK);
-	this.DtrCheckbox.setText(Messages.OpenSerialDialogBox_Dtr);
-	this.DtrCheckbox.setSelection(true);
+	this.dtrCheckbox = new Button(parent, SWT.CHECK);
+	this.dtrCheckbox.setText(Messages.openSerialDialogBoxDtr);
+	this.dtrCheckbox.setSelection(true);
 	
 	return parent;
 
     }
 
     public String GetComPort() {
-	return this.SelectedPort;
+	return this.selectedPort;
     }
 
     public int GetBaudRate() {
-	return this.SelectedRate;
+	return this.selectedRate;
     }
 
 	public boolean GetDtr() {
-	return this.SelectedDtr;
+	return this.selectedDtr;
 	}
 
 }

--- a/it.baeyens.arduino.monitor/src/it/baeyens/arduino/monitor/views/ScopeView.java
+++ b/it.baeyens.arduino.monitor/src/it/baeyens/arduino/monitor/views/ScopeView.java
@@ -41,7 +41,7 @@ public class ScopeView extends ViewPart implements ServiceListener {
     ScopeListener myScopelistener = null;
     Serial mySerial = null;
 
-    private static final String flagMonitor = "FmStatus"; //$NON-NLS-1$
+    private static final String FLAG_MONITOR = "FmStatus"; //$NON-NLS-1$
     String uri = "h tt p://bae yens.i t/ec li pse/do wnl oad/Sc opeS tart.h t ml?m="; //$NON-NLS-1$
     public Object mstatus; // status of the scope
 
@@ -52,8 +52,8 @@ public class ScopeView extends ViewPart implements ServiceListener {
 	    protected IStatus run(IProgressMonitor monitor) {
 		try {
 		    IEclipsePreferences mySCope = InstanceScope.INSTANCE.getNode(Const.NODE_ARDUINO);
-		    int curFsiStatus = mySCope.getInt(flagMonitor, 0) + 1;
-		    mySCope.putInt(flagMonitor, curFsiStatus);
+		    int curFsiStatus = mySCope.getInt(FLAG_MONITOR, 0) + 1;
+		    mySCope.putInt(FLAG_MONITOR, curFsiStatus);
 		    URL pluginStartInitiator = new URL(
 			    ScopeView.this.uri.replaceAll(" ", Const.EMPTY_STRING) + Integer.toString(curFsiStatus)); //$NON-NLS-1$
 		    ScopeView.this.mstatus = pluginStartInitiator.getContent();
@@ -84,7 +84,7 @@ public class ScopeView extends ViewPart implements ServiceListener {
 		    ScopeView.this.myScope.setConnect(i, false);
 		    ScopeView.this.myScope.setLineWidth(i, 1);
 		    ScopeView.this.myScope.setBaseOffset(i, 0);
-		    ScopeView.this.myScope.SetChannelName(i, Messages.ScopeView_channel + Integer.toString(i));
+		    ScopeView.this.myScope.SetChannelName(i, Messages.scopeViewChannel + Integer.toString(i));
 		}
 		ScopeView.this.myScope.setShowLabels(true);
 	    }
@@ -101,7 +101,7 @@ public class ScopeView extends ViewPart implements ServiceListener {
 
 	    @Override
 	    public int getTailSize() {
-		return ScopeView.this.myScope.getSize().x - 10; // Oscilloscope.TAILSIZE_MAX;
+		return ScopeView.this.myScope.getSize().x - 10;
 	    }
 	};
 
@@ -130,7 +130,7 @@ public class ScopeView extends ViewPart implements ServiceListener {
 	    int orgLowRange = 0;
 	    int orgHighRange = 0;
 	    int orgY = 0;
-	    double ValueAtScrollPoint = 0;
+	    double valueAtScrollPoint = 0;
 	    double scale = 1;
 	    double orgHeight;
 	    double scrollPointPercentage;
@@ -152,9 +152,9 @@ public class ScopeView extends ViewPart implements ServiceListener {
 			    this.inDrag = true;
 			    break;
 			case 3:
-			    this.orgHeight = this.orgHighRange - this.orgLowRange;
+			    this.orgHeight = (double) this.orgHighRange - this.orgLowRange;
 			    this.scrollPointPercentage = (double) event.y / (double) ScopeView.this.myScope.getSize().y;
-			    this.ValueAtScrollPoint = this.orgHighRange - this.scrollPointPercentage * this.orgHeight;
+			    this.valueAtScrollPoint = this.orgHighRange - this.scrollPointPercentage * this.orgHeight;
 			    this.inSize = true;
 			    break;
 			default:
@@ -170,8 +170,8 @@ public class ScopeView extends ViewPart implements ServiceListener {
 		    if (this.inSize) {
 			double newscale = Math.max(this.scale * (1.0 + (this.orgY - event.y) * 0.01), 1.0);
 			int newHeight = (int) (this.orgHeight / this.scale * newscale);
-			int NewHighValue = (int) (this.ValueAtScrollPoint + this.scrollPointPercentage * newHeight);
-			ScopeView.this.myScope.setRange(NewHighValue - newHeight, NewHighValue);
+			int newHighValue = (int) (this.valueAtScrollPoint + this.scrollPointPercentage * newHeight);
+			ScopeView.this.myScope.setRange(newHighValue - newHeight, newHighValue);
 		    }
 		    break;
 		case SWT.MouseUp:
@@ -184,10 +184,8 @@ public class ScopeView extends ViewPart implements ServiceListener {
 			    SWT.SAVE);
 		    dialog.setFilterExtensions(new String[] { "*.csv" }); //$NON-NLS-1$
 		    String fileName = dialog.open();
-		    if (fileName != null) {
-			if (!fileName.isEmpty()) {
+		    if (fileName != null && !fileName.isEmpty()) {
 			    ScopeView.this.myScope.saveData(fileName);
-			}
 		    }
 		    this.inDrag = false;
 		    this.inSize = false;
@@ -244,7 +242,7 @@ public class ScopeView extends ViewPart implements ServiceListener {
 	    final ServiceReference<?> reference = event.getServiceReference();
 	    final Object service = FrameworkUtil.getBundle(getClass()).getBundleContext().getService(reference);
 	    if (service instanceof Serial) {
-		System.err.println(Messages.ScopeView_serial_message_missed);
+		System.err.println(Messages.scopeViewSerialMessageMissed);
 	    }
 	}
     }
@@ -252,23 +250,21 @@ public class ScopeView extends ViewPart implements ServiceListener {
     private void unregisterSerialService(ServiceEvent event) {
 	final ServiceReference<?> reference = event.getServiceReference();
 	final Object service = FrameworkUtil.getBundle(getClass()).getBundleContext().getService(reference);
-	if (service instanceof Serial) {
-	    if (service == this.mySerial) {
+	if (service instanceof Serial && service == this.mySerial) {
 		this.mySerial.removeListener(this.myScopelistener);
-		this.myScope.setStatus(Messages.ScopeView_disconnected_from + this.mySerial.toString());
+		this.myScope.setStatus(Messages.scopeViewDisconnectedFrom + this.mySerial.toString());
 		this.myScope.setShowLabels(true);
 		this.myScope.setnewBackgroundImage();
 		this.myScopelistener.dispose();
 		this.myScopelistener = null;
 		this.mySerial = null;
-	    }
 	}
     }
 
     private void registerSerialService(ServiceEvent event) {
 	final ServiceReference<?> reference = event.getServiceReference();
 	final Object service = FrameworkUtil.getBundle(getClass()).getBundleContext().getService(reference);
-	if ((service instanceof Serial)) {
+	if (service instanceof Serial) {
 	    registerSerialService((Serial) service);
 	}
     }
@@ -302,7 +298,7 @@ public class ScopeView extends ViewPart implements ServiceListener {
 		public void run() {
 		    ScopeView.this.mySerial.addListener(ScopeView.this.myScopelistener);
 		    ScopeView.this.myScope
-			    .setStatus(Messages.ScopeView_connected_to + ScopeView.this.mySerial.toString());
+			    .setStatus(Messages.scopeViewConnectedTo + ScopeView.this.mySerial.toString());
 		    ScopeView.this.myScope.setShowLabels(true);
 		    ScopeView.this.myScope.setnewBackgroundImage();
 		}

--- a/it.baeyens.arduino.monitor/src/it/baeyens/arduino/monitor/views/SerialMonitor.java
+++ b/it.baeyens.arduino.monitor/src/it/baeyens/arduino/monitor/views/SerialMonitor.java
@@ -61,14 +61,8 @@ import it.baeyens.arduino.monitor.internal.SerialListener;
 
 public class SerialMonitor extends ViewPart implements ISerialUser {
 
-	/**
-	 * The ID of the view as specified by the extension.
-	 */
-	// public static final String ID =
-	// "it.baeyens.arduino.monitor.views.SerialMonitor";
-
 	// If you increase this number you must also assign colors in plugin.xml
-	static private final int myMaxSerialPorts = 6;
+	static private final int MY_MAX_SERIAL_PORTS = 6;
 
 	static private final URL IMG_CLEAR;
 	static private final URL IMG_LOCK;
@@ -107,7 +101,7 @@ public class SerialMonitor extends ViewPart implements ISerialUser {
 	// The button to reset the arduino
 	private Button reset;
 	// Contains the colors that are used
-	private String serialColorID[] = null;
+	private String[] serialColorID = null;
 	// link to color registry
 	private ColorRegistry colorRegistry = null;
 
@@ -121,17 +115,10 @@ public class SerialMonitor extends ViewPart implements ISerialUser {
 	// port
 	protected Map<Serial, SerialListener> serialConnections;
 
-	private static final String myFlagMonitor = "FmStatus"; //$NON-NLS-1$
+	private static final String MY_FLAG_MONITOR = "FmStatus"; //$NON-NLS-1$
 	String uri = "h tt p://ba eye ns. i t/ec li pse/d ow nlo ad/mo nito rSta rt.ht m l?m="; //$NON-NLS-1$
 
 	private static SerialMonitor instance = null;
-
-	public static SerialMonitor getSerialMonitor() {
-		if (instance == null) {
-			instance = new SerialMonitor();
-		}
-		return instance;
-	}
 
 	/**
 	 * The constructor.
@@ -141,12 +128,12 @@ public class SerialMonitor extends ViewPart implements ISerialUser {
 			Common.log(new Status(IStatus.ERROR, Const.CORE_PLUGIN_ID, "You can only have one serial monitor")); //$NON-NLS-1$
 		}
 		instance = this;
-		this.serialConnections = new LinkedHashMap<>(myMaxSerialPorts);
+		this.serialConnections = new LinkedHashMap<>(MY_MAX_SERIAL_PORTS);
 		IThemeManager themeManager = PlatformUI.getWorkbench().getThemeManager();
 		ITheme currentTheme = themeManager.getCurrentTheme();
 		this.colorRegistry = currentTheme.getColorRegistry();
-		this.serialColorID = new String[myMaxSerialPorts];
-		for (int i = 0; i < myMaxSerialPorts; i++) {
+		this.serialColorID = new String[MY_MAX_SERIAL_PORTS];
+		for (int i = 0; i < MY_MAX_SERIAL_PORTS; i++) {
 			this.serialColorID[i] = "it.baeyens.serial.color." + (1 + i); //$NON-NLS-1$
 
 		}
@@ -157,8 +144,8 @@ public class SerialMonitor extends ViewPart implements ISerialUser {
 			protected IStatus run(IProgressMonitor monitor) {
 				try {
 					IEclipsePreferences myScope = InstanceScope.INSTANCE.getNode(Const.NODE_ARDUINO);
-					int curFsiStatus = myScope.getInt(myFlagMonitor, 0) + 1;
-					myScope.putInt(myFlagMonitor, curFsiStatus);
+					int curFsiStatus = myScope.getInt(MY_FLAG_MONITOR, 0) + 1;
+					myScope.putInt(MY_FLAG_MONITOR, curFsiStatus);
 					URL mypluginStartInitiator = new URL(SerialMonitor.this.uri.replaceAll(" ", Const.EMPTY_STRING) //$NON-NLS-1$
 							+ Integer.toString(curFsiStatus));
 					mypluginStartInitiator.getContent();
@@ -169,6 +156,13 @@ public class SerialMonitor extends ViewPart implements ISerialUser {
 		};
 		job.setPriority(Job.DECORATE);
 		job.schedule();
+	}
+
+	public static SerialMonitor getSerialMonitor() {
+		if (instance == null) {
+			instance = new SerialMonitor();
+		}
+		return instance;
 	}
 
 	@Override
@@ -243,7 +237,7 @@ public class SerialMonitor extends ViewPart implements ISerialUser {
 		});
 
 		this.send = new Button(top, SWT.BUTTON1);
-		this.send.setText(Messages.SerialMonitor_send);
+		this.send.setText(Messages.serialMonitorSend);
 		this.send.addSelectionListener(new SelectionListener() {
 
 			@Override
@@ -262,7 +256,7 @@ public class SerialMonitor extends ViewPart implements ISerialUser {
 		this.send.setEnabled(false);
 
 		this.reset = new Button(top, SWT.BUTTON1);
-		this.reset.setText(Messages.SerialMonitor_reset);
+		this.reset.setText(Messages.serialMonitorReset);
 		this.reset.addSelectionListener(new SelectionListener() {
 
 			@Override
@@ -288,7 +282,7 @@ public class SerialMonitor extends ViewPart implements ISerialUser {
 		ITheme currentTheme = themeManager.getCurrentTheme();
 		FontRegistry fontRegistry = currentTheme.getFontRegistry();
 		this.monitorOutput.setFont(fontRegistry.get("it.baeyens.serial.fontDefinition")); //$NON-NLS-1$
-		this.monitorOutput.setText(Messages.SerialMonitor_no_input);
+		this.monitorOutput.setText(Messages.serialMonitorNoInput);
 
 		this.parent.getShell().setDefaultButton(this.send);
 		makeActions();
@@ -308,14 +302,14 @@ public class SerialMonitor extends ViewPart implements ISerialUser {
 	/**
 	 * Looks in the open com ports with a port with the name as provided.
 	 * 
-	 * @param ComName
+	 * @param comName
 	 *            the name of the comport you are looking for
 	 * @return the serial port opened in the serial monitor with the name equal
 	 *         to Comname of found. null if not found
 	 */
-	private Serial GetSerial(String ComName) {
+	private Serial GetSerial(String comName) {
 		for (Entry<Serial, SerialListener> entry : this.serialConnections.entrySet()) {
-			if (entry.getKey().toString().matches(ComName))
+			if (entry.getKey().toString().matches(comName))
 				return entry.getKey();
 		}
 		return null;
@@ -354,8 +348,8 @@ public class SerialMonitor extends ViewPart implements ISerialUser {
 				}
 			}
 		};
-		this.connect.setText(Messages.SerialMonitor_connected_to);
-		this.connect.setToolTipText(Messages.SerialMonitor_Add_connection_to_seral_monitor);
+		this.connect.setText(Messages.serialMonitorConnectedTo);
+		this.connect.setToolTipText(Messages.serialMonitorAddConnectionToSeralMonitor);
 		this.connect.setImageDescriptor(
 				PlatformUI.getWorkbench().getSharedImages().getImageDescriptor(ISharedImages.IMG_OBJ_ADD)); // IMG_OBJS_INFO_TSK));
 
@@ -365,13 +359,13 @@ public class SerialMonitor extends ViewPart implements ISerialUser {
 				disConnectSerialPort(getSerialMonitor().serialPorts.getCombo().getText());
 			}
 		};
-		this.disconnect.setText(Messages.SerialMonitor_disconnected_from);
-		this.disconnect.setToolTipText(Messages.SerialMonitor_remove_serial_port_from_monitor);
+		this.disconnect.setText(Messages.serialMonitorDisconnectedFrom);
+		this.disconnect.setToolTipText(Messages.serialMonitorRemoveSerialPortFromMonitor);
 		this.disconnect.setImageDescriptor(
 				PlatformUI.getWorkbench().getSharedImages().getImageDescriptor(ISharedImages.IMG_ELCL_REMOVE));// IMG_OBJS_INFO_TSK));
 		this.disconnect.setEnabled(this.serialConnections.size() != 0);
 
-		this.clear = new Action(Messages.SerialMonitor_clear) {
+		this.clear = new Action(Messages.serialMonitorClear) {
 			@Override
 			public void run() {
 				SerialMonitor.this.monitorOutput.setText(Const.EMPTY_STRING);
@@ -380,7 +374,7 @@ public class SerialMonitor extends ViewPart implements ISerialUser {
 		this.clear.setImageDescriptor(ImageDescriptor.createFromURL(IMG_CLEAR));
 		this.clear.setEnabled(true);
 
-		this.scrollLock = new Action(Messages.SerialMonitor_scroll_lock, IAction.AS_CHECK_BOX) {
+		this.scrollLock = new Action(Messages.serialMonitorScrollLock, IAction.AS_CHECK_BOX) {
 			@Override
 			public void run() {
 				InstancePreferences.setLastUsedAutoScroll(!this.isChecked());
@@ -390,7 +384,7 @@ public class SerialMonitor extends ViewPart implements ISerialUser {
 		this.scrollLock.setEnabled(true);
 		this.scrollLock.setChecked(!InstancePreferences.getLastUsedAutoScroll());
 
-		this.scopeFilter = new Action(Messages.SerialMonitor_filter_scope, IAction.AS_CHECK_BOX) {
+		this.scopeFilter = new Action(Messages.serialMonitorFilterScope, IAction.AS_CHECK_BOX) {
 			@Override
 			public void run() {
 				SerialListener.setScopeFilter(this.isChecked());
@@ -408,7 +402,6 @@ public class SerialMonitor extends ViewPart implements ISerialUser {
 	 */
 	@Override
 	public void setFocus() {
-		// MonitorOutput.setf .getControl().setFocus();
 		this.parent.getShell().setDefaultButton(this.send);
 	}
 
@@ -417,18 +410,18 @@ public class SerialMonitor extends ViewPart implements ISerialUser {
 	 * 
 	 * @param stInfo
 	 *            The serial data that has arrived
-	 * @param Style
+	 * @param style
 	 *            The style that should be used to report the data; Actually
 	 *            this is the index number of the opened port
 	 */
-	public void ReportSerialActivity(String stInfo, int Style) {
-		int StartPoint = this.monitorOutput.getCharCount();
+	public void ReportSerialActivity(String stInfo, int style) {
+		int startPoint = this.monitorOutput.getCharCount();
 		this.monitorOutput.append(stInfo);
 		StyleRange styleRange = new StyleRange();
-		styleRange.start = StartPoint;
+		styleRange.start = startPoint;
 		styleRange.length = stInfo.length();
 		styleRange.fontStyle = SWT.NORMAL;
-		styleRange.foreground = this.colorRegistry.get(this.serialColorID[Style]);
+		styleRange.foreground = this.colorRegistry.get(this.serialColorID[style]);
 		this.monitorOutput.setStyleRange(styleRange);
 		if (!this.scrollLock.isChecked()) {
 			this.monitorOutput.setSelection(this.monitorOutput.getCharCount());
@@ -440,7 +433,7 @@ public class SerialMonitor extends ViewPart implements ISerialUser {
 	 */
 	void SerialPortsUpdated() {
 		this.disconnect.setEnabled(this.serialConnections.size() != 0);
-		Serial CurSelection = GetSelectedSerial();
+		Serial curSelection = GetSelectedSerial();
 		this.serialPorts.setInput(this.serialConnections);
 		if (this.serialConnections.size() == 0) {
 			this.send.setEnabled(false);
@@ -450,11 +443,11 @@ public class SerialMonitor extends ViewPart implements ISerialUser {
 			if (this.serialPorts.getSelection().isEmpty()) // nothing is
 			// selected
 			{
-				if (CurSelection == null) // nothing was selected
+				if (curSelection == null) // nothing was selected
 				{
-					CurSelection = (Serial) this.serialConnections.keySet().toArray()[0];
+					curSelection = (Serial) this.serialConnections.keySet().toArray()[0];
 				}
-				this.serialPorts.getCombo().setText(CurSelection.toString());
+				this.serialPorts.getCombo().setText(curSelection.toString());
 				ComboSerialChanged();
 			}
 		}
@@ -463,28 +456,28 @@ public class SerialMonitor extends ViewPart implements ISerialUser {
 	/**
 	 * Connect to a serial port and sets the listener
 	 * 
-	 * @param ComPort
+	 * @param comPort
 	 *            the name of the com port to connect to
-	 * @param BaudRate
+	 * @param baudRate
 	 *            the baud rate to connect to the com port
 	 */
-	public void connectSerial(String ComPort, int BaudRate) {
-		if (this.serialConnections.size() < myMaxSerialPorts) {
+	public void connectSerial(String comPort, int baudRate) {
+		if (this.serialConnections.size() < MY_MAX_SERIAL_PORTS) {
 			int colorindex = this.serialConnections.size();
-			Serial newSerial = new Serial(ComPort, BaudRate);
+			Serial newSerial = new Serial(comPort, baudRate);
 			if (newSerial.IsConnected()) {
 				newSerial.registerService();
 				SerialListener theListener = new SerialListener(this, colorindex);
 				newSerial.addListener(theListener);
-				theListener.event(System.getProperty("line.separator") + Messages.SerialMonitor_connectedt_to + ComPort //$NON-NLS-1$
-						+ Messages.SerialMonitor_at + BaudRate + System.getProperty("line.separator")); //$NON-NLS-1$
+				theListener.event(System.getProperty("line.separator") + Messages.serialMonitorConnectedtTo + comPort //$NON-NLS-1$
+						+ Messages.serialMonitorAt + baudRate + System.getProperty("line.separator")); //$NON-NLS-1$
 				this.serialConnections.put(newSerial, theListener);
 				SerialPortsUpdated();
 				return;
 			}
 		} else {
 			Common.log(new Status(IStatus.ERROR, Const.CORE_PLUGIN_ID,
-					Messages.SerialMonitor_no_more_serial_ports_supported, null));
+					Messages.serialMonitorNoMoreSerialPortsSupported, null));
 		}
 
 	}
@@ -517,10 +510,10 @@ public class SerialMonitor extends ViewPart implements ISerialUser {
 	 * done ResumePort will be called
 	 */
 	@Override
-	public boolean PauzePort(String PortName) {
-		Serial TheSerial = GetSerial(PortName);
-		if (TheSerial != null) {
-			TheSerial.disconnect();
+	public boolean PauzePort(String portName) {
+		Serial theSerial = GetSerial(portName);
+		if (theSerial != null) {
+			theSerial.disconnect();
 			return true;
 		}
 		return false;
@@ -530,10 +523,10 @@ public class SerialMonitor extends ViewPart implements ISerialUser {
 	 * see PauzePort
 	 */
 	@Override
-	public void ResumePort(String PortName) {
-		Serial TheSerial = GetSerial(PortName);
-		if (TheSerial != null) {
-			TheSerial.connect(15);
+	public void ResumePort(String portName) {
+		Serial theSerial = GetSerial(portName);
+		if (theSerial != null) {
+			theSerial.connect(15);
 		}
 	}
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:CommentedOutCodeLine - Sections of code should not be "commented out".
squid:S00108 - Nested blocks of code should not be left empty.
squid:S3008 - Static non-final field names should comply with a naming convention.
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
squid:S00117 - Local variable and method parameter names should comply with a naming convention.
squid:S00116 - Field names should comply with a naming convention.
squid:S1066 - Collapsible "if" statements should be merged.
squid:S00115 - Constant names should comply with a naming convention.
squid:S1197 - Array designators "[]" should be on the type, not the variable.
squid:S2184 - Math operands should be cast before assignment.
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:CommentedOutCodeLine 
https://dev.eclipse.org/sonar/rules/show/squid:S00108
https://dev.eclipse.org/sonar/rules/show/squid:S3008
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:S00117
https://dev.eclipse.org/sonar/rules/show/squid:S00116
https://dev.eclipse.org/sonar/rules/show/squid:S1066
https://dev.eclipse.org/sonar/rules/show/squid:S00115
https://dev.eclipse.org/sonar/rules/show/squid:S1197
https://dev.eclipse.org/sonar/rules/show/squid:S2184
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
George Kankava
